### PR TITLE
POPUP次回非表示機能実装

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5533,56 +5533,6 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
-  data: function data() {
-    return {
-      notifications: [],
-      errorFlag: false
-    };
-  },
-  methods: {
-    show: function show() {
-      this.$modal.show('modal-window');
-      console.log(this.$modal.show);
-    },
-    hide: function hide() {
-      this.$modal.hide('modal-window');
-      console.log(this.$modal.hide);
-    }
-  },
-  mounted: function mounted() {
-    var _this = this;
-    axios.get('/api/notification/').then(function (response) {
-      _this.notifications = response.data.notifications;
-      console.log(_this.notifications);
-    })["catch"](function (response) {
-      return console.log(response);
-    });
-  },
-  computed: {
-    imgSrc: function imgSrc() {
-      for (var i = 0; i < 3; i++) {
-        var img = "/uploads/".concat(this.notifications[i].image);
-        console.log(img);
-        return img;
-      }
-    }
-  }
-});
-
-/***/ }),
-
-/***/ "./node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=script&lang=js&":
-/*!**********************************************************************************************************************************************************************************************************!*\
-  !*** ./node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=script&lang=js& ***!
-  \**********************************************************************************************************************************************************************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
 function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
 function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, defineProperty = Object.defineProperty || function (obj, key, desc) { obj[key] = desc.value; }, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return defineProperty(generator, "_invoke", { value: makeInvokeMethod(innerFn, self, context) }), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; defineProperty(this, "_invoke", { value: function value(method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); } }); } function makeInvokeMethod(innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; } function maybeInvokeDelegate(delegate, context) { var method = delegate.iterator[context.method]; if (undefined === method) { if (context.delegate = null, "throw" === context.method) { if (delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method)) return ContinueSentinel; context.method = "throw", context.arg = new TypeError("The iterator does not provide a 'throw' method"); } return ContinueSentinel; } var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) { if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; } return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, defineProperty(Gp, "constructor", { value: GeneratorFunctionPrototype, configurable: !0 }), defineProperty(GeneratorFunctionPrototype, "constructor", { value: GeneratorFunction, configurable: !0 }), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (val) { var object = Object(val), keys = []; for (var key in object) { keys.push(key); } return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) { "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); } }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
@@ -5592,11 +5542,11 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
     return {
       notifies: [],
       user_id: '',
-      notification_id: 16,
       hide_next: false,
       read: false,
       a: 0,
       b: 1,
+      i: 0,
       load: false
     };
   },
@@ -5609,47 +5559,70 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
       this.$modal.hide('modal-window');
       console.log(this.$modal.hide);
     },
+    hidePopup: function () {
+      var _hidePopup = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+        return _regeneratorRuntime().wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                if (!(this.read || this.hide_next)) {
+                  _context.next = 5;
+                  break;
+                }
+                this.load = true;
+                _context.next = 4;
+                return axios.post('/api/hidepopup', {
+                  'notification_id': this.notifies[this.i].id,
+                  'user_id': this.user_id,
+                  'read': this.read,
+                  'hide_next': this.hide_next
+                })["catch"](function (error) {
+                  console.log(error);
+                });
+              case 4:
+                this.load = false;
+              case 5:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee, this);
+      }));
+      function hidePopup() {
+        return _hidePopup.apply(this, arguments);
+      }
+      return hidePopup;
+    }(),
     nextPopup: function nextPopup() {
       if (this.a < this.notifies.length) {
         this.a++;
         this.b++;
+        this.hide_next = false;
+        this.read = false;
+        this.i++;
       }
       ;
-    },
-    hidePopup: function hidePopup() {
-      if (this.read || this.hide_next) {
-        axios.post('/api/hidepopup', {
-          'notification_id': this.notification_id,
-          'user_id': this.user_id,
-          'read': this.read,
-          'hide_next': this.hide_next
-        }).then(function (response) {
-          console.log(response);
-          this.hide_next = false;
-          this.read = false;
-        })["catch"](function (error) {
-          console.log(error);
-        });
-      }
     }
   },
   created: function created() {
     var _this = this;
-    return _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      return _regeneratorRuntime().wrap(function _callee$(_context) {
+    return _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
+      return _regeneratorRuntime().wrap(function _callee2$(_context2) {
         while (1) {
-          switch (_context.prev = _context.next) {
+          switch (_context2.prev = _context2.next) {
             case 0:
               if (!(sessionStorage.getItem('read') === null)) {
-                _context.next = 6;
+                _context2.next = 6;
                 break;
               }
               _this.load = true;
-              _context.next = 4;
+              _context2.next = 4;
               return axios.get('/api/notify').then(function (response) {
                 _this.notifies = response.data.notifies;
+                // this.notification_id = response.data.notifies;
                 _this.user_id = response.data.user_id;
                 console.log(_this.notifies);
+                console.log(_this.notifies[_this.i].id);
                 console.log(_this.user_id);
                 sessionStorage.setItem('read', 'true');
               })["catch"](function (response) {
@@ -5660,10 +5633,10 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
               _this.load = false;
             case 6:
             case "end":
-              return _context.stop();
+              return _context2.stop();
           }
         }
-      }, _callee);
+      }, _callee2);
     }))();
   }
 });
@@ -6061,58 +6034,6 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", [_c("button", {
-    staticClass: "button",
-    on: {
-      click: _vm.show
-    }
-  }, [_vm._v("モーダルを表示")]), _vm._v(" "), _vm._l(_vm.notifications, function (notification) {
-    return _c("modal", {
-      attrs: {
-        name: "modal-window",
-        draggable: true,
-        resizable: true
-      }
-    }, [_c("div", {
-      staticClass: "modal-header"
-    }, [_c("img", {
-      attrs: {
-        src: _vm.imgSrc
-      }
-    })]), _vm._v(" "), _c("div", {
-      staticClass: "modal-body"
-    }, [_c("p", [_vm._v("掲載期間：" + _vm._s(notification.start_date) + " 〜 " + _vm._s(notification.end_date))]), _vm._v(" "), _c("input", {
-      attrs: {
-        type: "checkbox"
-      }
-    }), _vm._v(_vm._s(notification.hide_next_time == 0 ? "次回から表示しない" : "") + "\n      "), _c("button", {
-      on: {
-        click: _vm.hide
-      }
-    }, [_vm._v("閉じる")])])]);
-  })], 2);
-};
-var staticRenderFns = [];
-render._withStripped = true;
-
-
-/***/ }),
-
-/***/ "./node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/lib/loaders/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=template&id=ff644bce&":
-/*!*********************************************************************************************************************************************************************************************************************************************************************************************!*\
-  !*** ./node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/lib/loaders/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=template&id=ff644bce& ***!
-  \*********************************************************************************************************************************************************************************************************************************************************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "render": () => (/* binding */ render),
-/* harmony export */   "staticRenderFns": () => (/* binding */ staticRenderFns)
-/* harmony export */ });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
   return _c("div", [_c("img", {
     directives: [{
       name: "show",
@@ -6174,34 +6095,34 @@ var render = function render() {
           }
         }
       }
-    })]) : notify.read === 1 ? _c("div", [_c("span", [_vm._v("読みました")]), _vm._v(" "), _c("input", {
+    })]) : notify.already_read === 1 ? _c("div", [_c("span", [_vm._v("読みました")]), _vm._v(" "), _c("input", {
       directives: [{
         name: "model",
         rawName: "v-model",
-        value: _vm.already_read,
-        expression: "already_read"
+        value: _vm.read,
+        expression: "read"
       }],
       attrs: {
         type: "checkbox"
       },
       domProps: {
-        checked: Array.isArray(_vm.already_read) ? _vm._i(_vm.already_read, null) > -1 : _vm.already_read
+        checked: Array.isArray(_vm.read) ? _vm._i(_vm.read, null) > -1 : _vm.read
       },
       on: {
         change: function change($event) {
-          var $$a = _vm.already_read,
+          var $$a = _vm.read,
             $$el = $event.target,
             $$c = $$el.checked ? true : false;
           if (Array.isArray($$a)) {
             var $$v = null,
               $$i = _vm._i($$a, $$v);
             if ($$el.checked) {
-              $$i < 0 && (_vm.already_read = $$a.concat([$$v]));
+              $$i < 0 && (_vm.read = $$a.concat([$$v]));
             } else {
-              $$i > -1 && (_vm.already_read = $$a.slice(0, $$i).concat($$a.slice($$i + 1)));
+              $$i > -1 && (_vm.read = $$a.slice(0, $$i).concat($$a.slice($$i + 1)));
             }
           } else {
-            _vm.already_read = $$c;
+            _vm.read = $$c;
           }
         }
       }
@@ -6229,7 +6150,7 @@ render._withStripped = true;
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var vue_router__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(/*! vue-router */ "./node_modules/vue-router/dist/vue-router.esm.js");
+/* harmony import */ var vue_router__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! vue-router */ "./node_modules/vue-router/dist/vue-router.esm.js");
 /* harmony import */ var vue_js_modal__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! vue-js-modal */ "./node_modules/vue-js-modal/dist/index.js");
 /* harmony import */ var vue_js_modal__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(vue_js_modal__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _components_HeaderComponent__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./components/HeaderComponent */ "./resources/js/components/HeaderComponent.vue");
@@ -6239,13 +6160,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _components_CreateComponent__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./components/CreateComponent */ "./resources/js/components/CreateComponent.vue");
 /* harmony import */ var _components_LoadingComponent__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./components/LoadingComponent */ "./resources/js/components/LoadingComponent.vue");
 /* harmony import */ var _components_NotificationComponent__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ./components/NotificationComponent */ "./resources/js/components/NotificationComponent.vue");
-/* harmony import */ var _components_NotifyComponent__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! ./components/NotifyComponent */ "./resources/js/components/NotifyComponent.vue");
 /**
  * First we will load all of this project's JavaScript dependencies which
  * includes Vue and other libraries. It is a great starting point when
  * building robust, powerful web applications using Vue and Laravel.
  */
-
 
 
 
@@ -6277,7 +6196,6 @@ Vue.component('home-component', _components_HomeComponent__WEBPACK_IMPORTED_MODU
 Vue.component('ceo-component', _components_CeoComponent__WEBPACK_IMPORTED_MODULE_4__["default"]);
 Vue.component('loading-component', _components_LoadingComponent__WEBPACK_IMPORTED_MODULE_6__["default"]);
 Vue.component('notification-component', _components_NotificationComponent__WEBPACK_IMPORTED_MODULE_7__["default"]);
-Vue.component('notify-component', _components_NotifyComponent__WEBPACK_IMPORTED_MODULE_8__["default"]);
 
 /**
  * Next, we will create a fresh Vue application instance and attach it to
@@ -6285,9 +6203,9 @@ Vue.component('notify-component', _components_NotifyComponent__WEBPACK_IMPORTED_
  * or customize the JavaScript scaffolding to fit your unique needs.
  */
 
-Vue.use(vue_router__WEBPACK_IMPORTED_MODULE_9__["default"]);
+Vue.use(vue_router__WEBPACK_IMPORTED_MODULE_8__["default"]);
 Vue.use((vue_js_modal__WEBPACK_IMPORTED_MODULE_0___default()));
-var router = new vue_router__WEBPACK_IMPORTED_MODULE_9__["default"]({
+var router = new vue_router__WEBPACK_IMPORTED_MODULE_8__["default"]({
   mode: 'history',
   routes: [{
     path: '/login',
@@ -6313,10 +6231,6 @@ var router = new vue_router__WEBPACK_IMPORTED_MODULE_9__["default"]({
     path: '/notification',
     name: 'notification',
     component: _components_NotificationComponent__WEBPACK_IMPORTED_MODULE_7__["default"]
-  }, {
-    path: '/notify',
-    name: 'notify',
-    component: _components_NotifyComponent__WEBPACK_IMPORTED_MODULE_8__["default"]
   }]
 });
 new Vue({
@@ -11609,30 +11523,6 @@ defineJQueryPlugin(Toast);
 /*!************************************************************************************************************************************************************************************************************************************************************************************************************************************************************!*\
   !*** ./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotificationComponent.vue?vue&type=style&index=0&id=307ad1f7&lang=css& ***!
   \************************************************************************************************************************************************************************************************************************************************************************************************************************************************************/
-/***/ ((module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
-/* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../../../node_modules/css-loader/dist/runtime/api.js */ "./node_modules/css-loader/dist/runtime/api.js");
-/* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__);
-// Imports
-
-var ___CSS_LOADER_EXPORT___ = _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0___default()(function(i){return i[1]});
-// Module
-___CSS_LOADER_EXPORT___.push([module.id, "\n.style1 {\n  font-family: 'Avenir', Helvetica, Arial, sans-serif;\n  -webkit-font-smoothing: antialiased;\n  -moz-osx-font-smoothing: grayscale;\n  text-align: center;\n  color: #2c3e50;\n  margin-top: 120px;\n}\n", ""]);
-// Exports
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (___CSS_LOADER_EXPORT___);
-
-
-/***/ }),
-
-/***/ "./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css&":
-/*!******************************************************************************************************************************************************************************************************************************************************************************************************************************************************!*\
-  !*** ./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css& ***!
-  \******************************************************************************************************************************************************************************************************************************************************************************************************************************************************/
 /***/ ((module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
@@ -29188,36 +29078,6 @@ var update = _node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js
 
 /***/ }),
 
-/***/ "./node_modules/style-loader/dist/cjs.js!./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css&":
-/*!**********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************!*\
-  !*** ./node_modules/style-loader/dist/cjs.js!./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css& ***!
-  \**********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
-/* harmony import */ var _node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! !../../../node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js */ "./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js");
-/* harmony import */ var _node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var _node_modules_css_loader_dist_cjs_js_clonedRuleSet_9_use_1_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_postcss_loader_dist_cjs_js_clonedRuleSet_9_use_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_style_index_0_id_ff644bce_lang_css___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! !!../../../node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!../../../node_modules/vue-loader/lib/loaders/stylePostLoader.js!../../../node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!../../../node_modules/vue-loader/lib/index.js??vue-loader-options!./NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css& */ "./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css&");
-
-            
-
-var options = {};
-
-options.insert = "head";
-options.singleton = false;
-
-var update = _node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js__WEBPACK_IMPORTED_MODULE_0___default()(_node_modules_css_loader_dist_cjs_js_clonedRuleSet_9_use_1_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_postcss_loader_dist_cjs_js_clonedRuleSet_9_use_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_style_index_0_id_ff644bce_lang_css___WEBPACK_IMPORTED_MODULE_1__["default"], options);
-
-
-
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_css_loader_dist_cjs_js_clonedRuleSet_9_use_1_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_postcss_loader_dist_cjs_js_clonedRuleSet_9_use_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_style_index_0_id_ff644bce_lang_css___WEBPACK_IMPORTED_MODULE_1__["default"].locals || {});
-
-/***/ }),
-
 /***/ "./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js":
 /*!****************************************************************************!*\
   !*** ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js ***!
@@ -29821,47 +29681,6 @@ component.options.__file = "resources/js/components/NotificationComponent.vue"
 
 /***/ }),
 
-/***/ "./resources/js/components/NotifyComponent.vue":
-/*!*****************************************************!*\
-  !*** ./resources/js/components/NotifyComponent.vue ***!
-  \*****************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
-/* harmony import */ var _NotifyComponent_vue_vue_type_template_id_ff644bce___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./NotifyComponent.vue?vue&type=template&id=ff644bce& */ "./resources/js/components/NotifyComponent.vue?vue&type=template&id=ff644bce&");
-/* harmony import */ var _NotifyComponent_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./NotifyComponent.vue?vue&type=script&lang=js& */ "./resources/js/components/NotifyComponent.vue?vue&type=script&lang=js&");
-/* harmony import */ var _NotifyComponent_vue_vue_type_style_index_0_id_ff644bce_lang_css___WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css& */ "./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css&");
-/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! !../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
-
-
-
-;
-
-
-/* normalize component */
-
-var component = (0,_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_3__["default"])(
-  _NotifyComponent_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
-  _NotifyComponent_vue_vue_type_template_id_ff644bce___WEBPACK_IMPORTED_MODULE_0__.render,
-  _NotifyComponent_vue_vue_type_template_id_ff644bce___WEBPACK_IMPORTED_MODULE_0__.staticRenderFns,
-  false,
-  null,
-  null,
-  null
-  
-)
-
-/* hot reload */
-if (false) { var api; }
-component.options.__file = "resources/js/components/NotifyComponent.vue"
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (component.exports);
-
-/***/ }),
-
 /***/ "./resources/js/components/CeoComponent.vue?vue&type=script&lang=js&":
 /*!***************************************************************************!*\
   !*** ./resources/js/components/CeoComponent.vue?vue&type=script&lang=js& ***!
@@ -29987,22 +29806,6 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var _node_modules_babel_loader_lib_index_js_clonedRuleSet_5_use_0_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationComponent_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!../../../node_modules/vue-loader/lib/index.js??vue-loader-options!./NotificationComponent.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotificationComponent.vue?vue&type=script&lang=js&");
  /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_babel_loader_lib_index_js_clonedRuleSet_5_use_0_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationComponent_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
-
-/***/ }),
-
-/***/ "./resources/js/components/NotifyComponent.vue?vue&type=script&lang=js&":
-/*!******************************************************************************!*\
-  !*** ./resources/js/components/NotifyComponent.vue?vue&type=script&lang=js& ***!
-  \******************************************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_clonedRuleSet_5_use_0_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!../../../node_modules/vue-loader/lib/index.js??vue-loader-options!./NotifyComponent.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=script&lang=js&");
- /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_babel_loader_lib_index_js_clonedRuleSet_5_use_0_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
 
 /***/ }),
 
@@ -30142,23 +29945,6 @@ __webpack_require__.r(__webpack_exports__);
 
 /***/ }),
 
-/***/ "./resources/js/components/NotifyComponent.vue?vue&type=template&id=ff644bce&":
-/*!************************************************************************************!*\
-  !*** ./resources/js/components/NotifyComponent.vue?vue&type=template&id=ff644bce& ***!
-  \************************************************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "render": () => (/* reexport safe */ _node_modules_babel_loader_lib_index_js_clonedRuleSet_5_use_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ruleSet_1_rules_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_template_id_ff644bce___WEBPACK_IMPORTED_MODULE_0__.render),
-/* harmony export */   "staticRenderFns": () => (/* reexport safe */ _node_modules_babel_loader_lib_index_js_clonedRuleSet_5_use_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ruleSet_1_rules_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_template_id_ff644bce___WEBPACK_IMPORTED_MODULE_0__.staticRenderFns)
-/* harmony export */ });
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_clonedRuleSet_5_use_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ruleSet_1_rules_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_template_id_ff644bce___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!../../../node_modules/vue-loader/lib/loaders/templateLoader.js??ruleSet[1].rules[2]!../../../node_modules/vue-loader/lib/index.js??vue-loader-options!./NotifyComponent.vue?vue&type=template&id=ff644bce& */ "./node_modules/babel-loader/lib/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/lib/loaders/templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=template&id=ff644bce&");
-
-
-/***/ }),
-
 /***/ "./resources/js/components/NotificationComponent.vue?vue&type=style&index=0&id=307ad1f7&lang=css&":
 /*!********************************************************************************************************!*\
   !*** ./resources/js/components/NotificationComponent.vue?vue&type=style&index=0&id=307ad1f7&lang=css& ***!
@@ -30168,19 +29954,6 @@ __webpack_require__.r(__webpack_exports__);
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _node_modules_style_loader_dist_cjs_js_node_modules_css_loader_dist_cjs_js_clonedRuleSet_9_use_1_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_postcss_loader_dist_cjs_js_clonedRuleSet_9_use_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationComponent_vue_vue_type_style_index_0_id_307ad1f7_lang_css___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/style-loader/dist/cjs.js!../../../node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!../../../node_modules/vue-loader/lib/loaders/stylePostLoader.js!../../../node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!../../../node_modules/vue-loader/lib/index.js??vue-loader-options!./NotificationComponent.vue?vue&type=style&index=0&id=307ad1f7&lang=css& */ "./node_modules/style-loader/dist/cjs.js!./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotificationComponent.vue?vue&type=style&index=0&id=307ad1f7&lang=css&");
-
-
-/***/ }),
-
-/***/ "./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css&":
-/*!**************************************************************************************************!*\
-  !*** ./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css& ***!
-  \**************************************************************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_style_loader_dist_cjs_js_node_modules_css_loader_dist_cjs_js_clonedRuleSet_9_use_1_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_postcss_loader_dist_cjs_js_clonedRuleSet_9_use_2_node_modules_vue_loader_lib_index_js_vue_loader_options_NotifyComponent_vue_vue_type_style_index_0_id_ff644bce_lang_css___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/style-loader/dist/cjs.js!../../../node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!../../../node_modules/vue-loader/lib/loaders/stylePostLoader.js!../../../node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!../../../node_modules/vue-loader/lib/index.js??vue-loader-options!./NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css& */ "./node_modules/style-loader/dist/cjs.js!./node_modules/css-loader/dist/cjs.js??clonedRuleSet-9.use[1]!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??clonedRuleSet-9.use[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./resources/js/components/NotifyComponent.vue?vue&type=style&index=0&id=ff644bce&lang=css&");
 
 
 /***/ }),

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -13,7 +13,6 @@ import CeoComponent from "./components/CeoComponent";
 import CreateComponent from "./components/CreateComponent";
 import LoadingComponent from "./components/LoadingComponent";
 import NotificationComponent from "./components/NotificationComponent";
-import NotifyComponent from "./components/NotifyComponent";
 
 require('./bootstrap');
 
@@ -37,7 +36,6 @@ Vue.component('home-component', HomeComponent);
 Vue.component('ceo-component', CeoComponent);
 Vue.component('loading-component', LoadingComponent);
 Vue.component('notification-component', NotificationComponent);
-Vue.component('notify-component', NotifyComponent);
 
 
 /**
@@ -81,11 +79,6 @@ Vue.component('notify-component', NotifyComponent);
             path: '/notification',
             name: 'notification',
             component: NotificationComponent,
-        },
-        {
-            path: '/notify',
-            name: 'notify',
-            component: NotifyComponent,
         },
      ]
  });

--- a/resources/js/components/NotificationComponent.vue
+++ b/resources/js/components/NotificationComponent.vue
@@ -1,25 +1,47 @@
 <template>
-<div>
-  <button v-on:click="show" class="button">モーダルを表示</button>
-  <modal name='modal-window' :draggable="true" :resizable="true" v-for="notification in notifications">
-    <div class="modal-header">
-      <img :src="imgSrc">
-    </div>
-    <div class="modal-body">
-      <p>掲載期間：{{ notification.start_date }} 〜 {{ notification.end_date }}</p>
-      <input type="checkbox">{{ notification.hide_next_time == 0  ? '次回から表示しない' : '' }}
-      <button v-on:click="hide">閉じる</button>
-    </div>
-  </modal>
-</div>
+  <div>
+    <img src="../../../image/loading.gif" v-show="load">
+
+    <modal name='modal-window' v-for="(notify, index) in notifies.slice(a,b)" :key="index" :clickToClose="false" :reset="true" :trandition="false" :draggable="true" :resizable="true">
+      <div class="modal-header">
+        <img :src="`/uploads/${notify.image}`">
+      </div>
+
+      <div class="modal-body">
+
+        <div v-if="notify.hide_next_time === 1">
+          <span>次回から表示しない</span>
+          <input type="checkbox" v-model="hide_next" value=true>
+        </div>
+        <div v-else-if="notify.already_read === 1">
+          <span>読みました</span>
+          <input type="checkbox" v-model="read">
+        </div>
+        <div v-else>
+          <p>メンテナンス系</p>
+        </div>
+
+      <button @click="hidePopup(); nextPopup();">閉じる</button>
+
+      </div>
+
+    </modal>
+  </div>
 </template>
 
+<!-- Script -->
 <script>
 export default {
-  data: function() {
+  data () {
     return {
-      notifications: [],
-      errorFlag: false,
+      notifies: [],
+      user_id: '',
+      hide_next: false,
+      read: false,
+      a: 0,
+      b: 1,
+      i: 0,
+      load: false,
     }
   },
   methods: {
@@ -31,28 +53,52 @@ export default {
       this.$modal.hide('modal-window');
       console.log(this.$modal.hide);
     },
-  },
-  mounted() {
-    axios.get('/api/notification/')
-    .then(response => {
-      this.notifications = response.data.notifications;
-      console.log(this.notifications)
-    })
-    .catch(response => console.log(response));
-  },
-  computed: {
-    imgSrc: function() {
-      for(let i=0; i<3; i++){
-        const img = `/uploads/${this.notifications[i].image}`;
-        console.log(img);
-        return img;
+    hidePopup : async function () {
+      if(this.read || this.hide_next) {
+        this.load = true;
+        await axios.post('/api/hidepopup', {
+          'notification_id': this.notifies[this.i].id,
+          'user_id': this.user_id,
+          'read': this.read,
+          'hide_next': this.hide_next,
+        })
+        .catch(function (error) { 
+          console.log(error);
+        })
+        this.load = false;
       }
-        
+    },
+    nextPopup : function () {
+      if(this.a < this.notifies.length) {
+        this.a++;
+        this.b++;
+        this.hide_next = false;
+        this.read = false;
+        this.i++;
+      };
+    },
+  },
+  async created() {
+    if(sessionStorage.getItem('read') === null) {
+      this.load = true;
+      await axios.get('/api/notify')
+      .then(response => {
+        this.notifies = response.data.notifies;
+        // this.notification_id = response.data.notifies;
+        this.user_id = response.data.user_id;
+        console.log(this.notifies);
+        console.log(this.notifies[this.i].id);
+        console.log(this.user_id);
+        sessionStorage.setItem('read', 'true');
+      })
+      .catch(response => console.log(response));
+      this.show();
+      this.load = false;
     }
   }
 }
 </script>
-
+<!-- CSS -->
 <style>
 .style1 {
   font-family: 'Avenir', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
APIのリクエストはPostmanを使用し確認済。
Vue.jsからAPIへのリクエストにフォーカスして実装。

- POSTしたPOPUPのIDを取得
- 次回から非表示をチェックして閉じる→APIへPOST
- POSTしたらdataプロパティの値をリセット
- 非表示送信時、インジケーターを表示してUI向上